### PR TITLE
Fix `fisher install` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ are set properly in `$PATH`.
 Install with [Fisher][] (recommended):
 
 ```fish
-fisher install halostatue/fish-go@2.x
+fisher install halostatue/fish-go@v2.x
 ```
 
 <details>


### PR DESCRIPTION
```
$ fisher install halostatue/fish-go@2.x
fisher install version 4.4.2
Fetching https://api.github.com/repos/halostatue/fish-go/tarball/2.x
fisher: Invalid plugin name or host unavailable: "halostatue/fish-go@2.x"

$ fisher install halostatue/fish-go@v2.x
fisher install version 4.4.2
Fetching https://api.github.com/repos/halostatue/fish-go/tarball/v2.x
Installing halostatue/fish-go@v2.x
           /Users/joschi/.config/fish/conf.d/halostatue_fish_go.fish
Installed 1 plugin/s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/fish-go/1)
<!-- Reviewable:end -->
